### PR TITLE
Fix: Set server host per environment

### DIFF
--- a/src/variables/index.js
+++ b/src/variables/index.js
@@ -1,19 +1,22 @@
 let GAME_HOST;
+let SECURE = 's';
 switch (window.location.hostname) {
   case 'localhost':
     GAME_HOST = 'localhost:3000';
+    SECURE = '';
     break;
   case 'playcodewords.com':
   case 'www.playcodewords.com':
-    GAME_HOST = 'codewords-server.herokuapp.com'
+    GAME_HOST = 'codewords-server.herokuapp.com';
+    break;
   default:
     GAME_HOST = window.location.hostname.replace('game', 'server');
 }
 
 console.dir(process.env);
 
-export const API_ROOT = `http://${GAME_HOST}/api`;
-export const API_WS_ROOT = `ws://${GAME_HOST}/cable`;
+export const API_ROOT = `http${SECURE}://${GAME_HOST}/api`;
+export const API_WS_ROOT = `ws${SECURE}://${GAME_HOST}/cable`;
 export const HEADERS = {
   'Content-Type': 'application/json',
   Accept: 'application/json',

--- a/src/variables/index.js
+++ b/src/variables/index.js
@@ -13,8 +13,6 @@ switch (window.location.hostname) {
     GAME_HOST = window.location.hostname.replace('game', 'server');
 }
 
-console.dir(process.env);
-
 export const API_ROOT = `http${SECURE}://${GAME_HOST}/api`;
 export const API_WS_ROOT = `ws${SECURE}://${GAME_HOST}/cable`;
 export const HEADERS = {


### PR DESCRIPTION
# Description

Solving production issues. Set API_ROOT and API_WS_ROOT programmatically depending upon where we're running:
- On localhost -> localhost:3000
- On staging -> codewords-server-staging.herokuapp.com
- In production -> codewords-server.herokuapp.com

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:


## Has This Been Tested?

- [ ] No
- [x] Yes
   Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
   Manually tested by seeing effects in different environments. 
- [ ] Have any prior tests been changed?
If so, please explain:


# Additional notes:
Production joy!


# Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no console logs
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas